### PR TITLE
🐞 fix for context byte streaming

### DIFF
--- a/docs/public/static/changelog/iotFtpsClient.md
+++ b/docs/public/static/changelog/iotFtpsClient.md
@@ -4,6 +4,10 @@ title: iot-ftps-client Changelog
 
 # Release History for iot-ftps-client
 
+### 1.0.1 (08/30/2022)
+
+- Bug fix for uploading byte streams from within a context
+
 ### 1.0.0 (08/29/2022)
 
 - Initial Release

--- a/iot-ftps-client/CHANGELOG.md
+++ b/iot-ftps-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.1 (08/30/2022)
+
+- Bug fix for uploading byte streams from within a context
+
 ## 1.0.0 (08/29/2022)
 
 - Initial Release

--- a/iot-ftps-client/iot/ftps/client/_client.py
+++ b/iot-ftps-client/iot/ftps/client/_client.py
@@ -107,7 +107,7 @@ class IoTFTPSClient:
         """upload a file to a path inside the FTPS server"""
         try:
             with open(source, "rb") as file:
-                self.ftps_session.storbinary(f"STOR {dest}", file.read)
+                self.ftps_session.storbinary(f"STOR {dest}", file)
             return True
         except Exception as ex:
             print(f"unexpected exception occurred: {ex}")

--- a/iot-ftps-client/iot/ftps/client/_version.py
+++ b/iot-ftps-client/iot/ftps/client/_version.py
@@ -1,3 +1,3 @@
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 __version__ = VERSION


### PR DESCRIPTION
# PR: iot-ftps-client storbinary bug

closes #30

## Description

When leveraging the `upload_file` function, the storbinary call attempts to read the file from within an open context.  It should simply pass the bytes of the opened file instead of reading - this currently causes the function to fail.

These changes are (delete options that aren't relevant and check the options that are):

- [x] Non-Breaking Bug Fix (bug fix that doesn't break existing code)
- [x] Documentation

## PR Checklist

Please check the completed items (delete options that aren't relevant and check the options that are):

- [x] unit tests succeeded
- [x] documentation updated
- [x] versions updated
